### PR TITLE
Improving performance of LinkedList.RemoveBack

### DIFF
--- a/linkedlist.go
+++ b/linkedlist.go
@@ -207,8 +207,8 @@ func (list *LinkedList) RemoveBack() (interface{}, bool) {
 	if list.length == 0 {
 		list.first = nil
 	} else {
-		node, _ := get(list.first, list.length-1)
-		node.next = nil
+		list.last = list.last.prev
+		list.last.next = nil
 	}
 	return retval, true
 }

--- a/linkedlist_test.go
+++ b/linkedlist_test.go
@@ -141,6 +141,14 @@ func UncheckedComparatori(a, b interface{}) (int, error) {
 	return a.(int) - b.(int), nil
 }
 
+func TestLinkedList_RemoveBack_single(t *testing.T) {
+	subject := NewLinkedList(1)
+	subject.RemoveBack()
+	if subject.Length() != 0 {
+		t.Fail()
+	}
+}
+
 func TestLinkedList_Sorti(t *testing.T) {
 	testCases := []struct {
 		*LinkedList


### PR DESCRIPTION
When LinkedList was made doubly linked, this improvement was missed. We need not do a O(n) operation to get the second to last element, we can just grab it.