### PR TITLE
Use Context for Cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Converting between slices and a queryable structure is as trivial as it should b
 original := []interface{}{"a", "b", "c"}
 subject := collection.AsEnumerable(original...)
 
-for entry := range subject.Enumerate(nil) {
+for entry := range subject.Enumerate(context.Background()) {
     fmt.Println(entry)
 }
 // Output:
@@ -28,7 +28,7 @@ subject := collection.AsEnumerable(1, 2, 3, 4, 5, 6)
 filtered := collection.Where(subject, func(num interface{}) bool{
     return num.(int) > 3
 })
-for entry := range filtered.Enumerate(nil) {
+for entry := range filtered.Enumerate(context.Background()) {
     fmt.Println(entry)
 }
 // Output:
@@ -42,7 +42,7 @@ subject := collection.AsEnumerable(1, 2, 3, 4, 5, 6)
 updated := collection.Select(subject, func(num interface{}) interface{}{
     return num.(int) + 10
 })
-for entry := range updated.Enumerate(nil) {
+for entry := range updated.Enumerate(context.Background()) {
     fmt.Println(entry)
 }
 // Output:

--- a/dictionary.go
+++ b/dictionary.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"context"
 	"sort"
 )
 
@@ -130,14 +131,14 @@ func (dict Dictionary) Size() int64 {
 }
 
 // Enumerate lists each word in the Dictionary alphabetically.
-func (dict Dictionary) Enumerate(cancel <-chan struct{}) Enumerator {
+func (dict Dictionary) Enumerate(ctx context.Context) Enumerator {
 	if dict.root == nil {
-		return Empty.Enumerate(cancel)
+		return Empty.Enumerate(ctx)
 	}
-	return dict.root.Enumerate(cancel)
+	return dict.root.Enumerate(ctx)
 }
 
-func (node trieNode) Enumerate(cancel <-chan struct{}) Enumerator {
+func (node trieNode) Enumerate(ctx context.Context) Enumerator {
 	var enumerateHelper func(trieNode, string)
 
 	results := make(chan interface{})
@@ -146,7 +147,7 @@ func (node trieNode) Enumerate(cancel <-chan struct{}) Enumerator {
 		if subject.IsWord {
 			select {
 			case results <- prefix:
-			case <-cancel:
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/dictionary_examples_test.go
+++ b/dictionary_examples_test.go
@@ -1,10 +1,11 @@
 package collection_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"github.com/marstr/collection"
+	"github.com/marstr/collection/v2"
 )
 
 func ExampleDictionary_Add() {
@@ -54,11 +55,11 @@ func ExampleDictionary_Enumerate() {
 		return strings.ToUpper(x.(string))
 	})
 
-	for word := range subject.Enumerate(nil) {
+	for word := range subject.Enumerate(context.Background()) {
 		fmt.Println(word)
 	}
 
-	for word := range upperCase.Enumerate(nil) {
+	for word := range upperCase.Enumerate(context.Background()) {
 		fmt.Println(word)
 	}
 

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -38,7 +39,7 @@ func TestDictionary_Enumerate(t *testing.T) {
 			}
 
 			prev := ""
-			for result := range subject.Enumerate(nil) {
+			for result := range subject.Enumerate(context.Background()) {
 				t.Logf(result.(string))
 				if alreadySeen, ok := expected[result.(string)]; !ok {
 					t.Logf("An unadded value was returned")

--- a/doc.go
+++ b/doc.go
@@ -11,7 +11,7 @@
 // 		Location: "./",
 // 	}
 //
-// 	results := myDir.Enumerate(nil).Where(func(x interface{}) bool {
+// 	results := myDir.Enumerate(context.Background()).Where(func(x interface{}) bool {
 // 		return strings.HasSuffix(x.(string), ".go")
 // 	})
 //

--- a/fibonacci.go
+++ b/fibonacci.go
@@ -1,11 +1,13 @@
 package collection
 
+import "context"
+
 type fibonacciGenerator struct{}
 
 // Fibonacci is an Enumerable which will dynamically generate the fibonacci sequence.
 var Fibonacci Enumerable = fibonacciGenerator{}
 
-func (gen fibonacciGenerator) Enumerate(cancel <-chan struct{}) Enumerator {
+func (gen fibonacciGenerator) Enumerate(ctx context.Context) Enumerator {
 	retval := make(chan interface{})
 
 	go func() {
@@ -16,7 +18,7 @@ func (gen fibonacciGenerator) Enumerate(cancel <-chan struct{}) Enumerator {
 			select {
 			case retval <- a:
 				a, b = b, a+b
-			case <-cancel:
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/filesystem.go
+++ b/filesystem.go
@@ -1,7 +1,7 @@
 package collection
 
 import (
-	"errors"
+	"context"
 	"os"
 	"path/filepath"
 )
@@ -40,7 +40,7 @@ func (d Directory) applyOptions(loc string, info os.FileInfo) bool {
 }
 
 // Enumerate lists the items in a `Directory`
-func (d Directory) Enumerate(cancel <-chan struct{}) Enumerator {
+func (d Directory) Enumerate(ctx context.Context) Enumerator {
 	results := make(chan interface{})
 
 	go func() {
@@ -64,8 +64,8 @@ func (d Directory) Enumerate(cancel <-chan struct{}) Enumerator {
 				select {
 				case results <- currentLocation:
 					// Intentionally Left Blank
-				case <-cancel:
-					err = errors.New("directory enumeration cancelled")
+				case <-ctx.Done():
+					err = ctx.Err()
 				}
 			}
 

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"path"
@@ -54,9 +55,7 @@ func ExampleDirectory_Enumerate() {
 		Options:  DirectoryOptionsExcludeDirectories,
 	}
 
-	done := make(chan struct{})
-
-	filesOfInterest := traverser.Enumerate(done).Select(func(subject interface{}) (result interface{}) {
+	filesOfInterest := traverser.Enumerate(context.Background()).Select(func(subject interface{}) (result interface{}) {
 		cast, ok := subject.(string)
 		if ok {
 			result = path.Base(cast)
@@ -75,7 +74,6 @@ func ExampleDirectory_Enumerate() {
 	for entry := range filesOfInterest {
 		fmt.Println(entry.(string))
 	}
-	close(done)
 
 	// Output: filesystem_test.go
 }
@@ -146,7 +144,7 @@ func TestDirectory_Enumerate(t *testing.T) {
 	for _, tc := range testCases {
 		subject.Options = tc.options
 		t.Run(fmt.Sprintf("%d", uint(tc.options)), func(t *testing.T) {
-			for entry := range subject.Enumerate(nil) {
+			for entry := range subject.Enumerate(context.Background()) {
 				cast := entry.(string)
 				if _, ok := tc.expected[cast]; !ok {
 					t.Logf("unexpected result: %q", cast)

--- a/linkedlist.go
+++ b/linkedlist.go
@@ -2,6 +2,7 @@ package collection
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -98,7 +99,7 @@ func (list *LinkedList) addNodeFront(node *llNode) {
 }
 
 // Enumerate creates a new instance of Enumerable which can be executed on.
-func (list *LinkedList) Enumerate(cancel <-chan struct{}) Enumerator {
+func (list *LinkedList) Enumerate(ctx context.Context) Enumerator {
 	retval := make(chan interface{})
 
 	go func() {
@@ -111,7 +112,7 @@ func (list *LinkedList) Enumerate(cancel <-chan struct{}) Enumerator {
 			select {
 			case retval <- current.payload:
 				break
-			case <-cancel:
+			case <-ctx.Done():
 				return
 			}
 			current = current.next
@@ -356,7 +357,7 @@ func (list *LinkedList) moveToFront(node *llNode) {
 
 // ToSlice converts the contents of the LinkedList into a slice.
 func (list *LinkedList) ToSlice() []interface{} {
-	return list.Enumerate(nil).ToSlice()
+	return list.Enumerate(context.Background()).ToSlice()
 }
 
 func findLast(head *llNode) *llNode {

--- a/linkedlist_examples_test.go
+++ b/linkedlist_examples_test.go
@@ -1,9 +1,10 @@
 package collection_test
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/marstr/collection"
+	"github.com/marstr/collection/v2"
 )
 
 func ExampleLinkedList_AddFront() {
@@ -27,7 +28,7 @@ func ExampleLinkedList_AddBack() {
 
 func ExampleLinkedList_Enumerate() {
 	subject := collection.NewLinkedList(2, 3, 5, 8)
-	results := subject.Enumerate(nil).Select(func(a interface{}) interface{} {
+	results := subject.Enumerate(context.Background()).Select(func(a interface{}) interface{} {
 		return -1 * a.(int)
 	})
 	for entry := range results {

--- a/linkedlist_test.go
+++ b/linkedlist_test.go
@@ -1,6 +1,9 @@
 package collection
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestLinkedList_findLast_empty(t *testing.T) {
 	if result := findLast(nil); result != nil {
@@ -101,7 +104,7 @@ func TestLinkedList_mergeSort_repair(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.String(), func(t *testing.T) {
 			originalLength := tc.Length()
-			originalElements := tc.Enumerate(nil).ToSlice()
+			originalElements := tc.Enumerate(context.Background()).ToSlice()
 			originalContents := tc.String()
 
 			if err := tc.Sorti(); err != ErrUnexpectedType {
@@ -116,7 +119,7 @@ func TestLinkedList_mergeSort_repair(t *testing.T) {
 				t.Fail()
 			}
 
-			remaining := tc.Enumerate(nil).ToSlice()
+			remaining := tc.Enumerate(context.Background()).ToSlice()
 
 			for _, desired := range originalElements {
 				found := false

--- a/list.go
+++ b/list.go
@@ -2,6 +2,7 @@ package collection
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sync"
 )
@@ -38,7 +39,7 @@ func (l *List) AddAt(pos uint, entries ...interface{}) {
 }
 
 // Enumerate lists each element present in the collection
-func (l *List) Enumerate(cancel <-chan struct{}) Enumerator {
+func (l *List) Enumerate(ctx context.Context) Enumerator {
 	retval := make(chan interface{})
 
 	go func() {
@@ -50,7 +51,7 @@ func (l *List) Enumerate(cancel <-chan struct{}) Enumerator {
 			select {
 			case retval <- entry:
 				break
-			case <-cancel:
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/lru_example_test.go
+++ b/lru_example_test.go
@@ -3,7 +3,7 @@ package collection_test
 import (
 	"context"
 	"fmt"
-	"github.com/marstr/collection"
+	"github.com/marstr/collection/v2"
 )
 
 func ExampleLRUCache() {
@@ -20,14 +20,13 @@ func ExampleLRUCache() {
 }
 
 func ExampleLRUCache_Enumerate() {
-	ctx := context.Background()
 	subject := collection.NewLRUCache(3)
 	subject.Put(1, "one")
 	subject.Put(2, "two")
 	subject.Put(3, "three")
 	subject.Put(4, "four")
 
-	for key := range subject.Enumerate(ctx.Done()) {
+	for key := range subject.Enumerate(context.Background()) {
 		fmt.Println(key)
 	}
 
@@ -38,14 +37,13 @@ func ExampleLRUCache_Enumerate() {
 }
 
 func ExampleLRUCache_EnumerateKeys() {
-	ctx := context.Background()
 	subject := collection.NewLRUCache(3)
 	subject.Put(1, "one")
 	subject.Put(2, "two")
 	subject.Put(3, "three")
 	subject.Put(4, "four")
 
-	for key := range subject.EnumerateKeys(ctx.Done()) {
+	for key := range subject.EnumerateKeys(context.Background()) {
 		fmt.Println(key)
 	}
 

--- a/query_examples_test.go
+++ b/query_examples_test.go
@@ -1,10 +1,11 @@
 package collection_test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
-	"github.com/marstr/collection"
+	"github.com/marstr/collection/v2"
 )
 
 func ExampleAsEnumerable() {
@@ -12,14 +13,14 @@ func ExampleAsEnumerable() {
 	original := []int{1, 2, 3, 4, 5}
 	wrapped := collection.AsEnumerable(original)
 
-	for entry := range wrapped.Enumerate(nil) {
+	for entry := range wrapped.Enumerate(context.Background()) {
 		fmt.Print(entry)
 	}
 	fmt.Println()
 
 	// When multiple values are provided, regardless of their type, they are each treated as enumerable values.
 	wrapped = collection.AsEnumerable("red", "orange", "yellow", "green", "blue", "indigo", "violet")
-	for entry := range wrapped.Enumerate(nil) {
+	for entry := range wrapped.Enumerate(context.Background()) {
 		fmt.Println(entry)
 	}
 	// Output:
@@ -35,7 +36,7 @@ func ExampleAsEnumerable() {
 
 func ExampleEnumerator_Count() {
 	subject := collection.AsEnumerable("str1", "str1", "str2")
-	count1 := subject.Enumerate(nil).Count(func(a interface{}) bool {
+	count1 := subject.Enumerate(context.Background()).Count(func(a interface{}) bool {
 		return a == "str1"
 	})
 	fmt.Println(count1)
@@ -44,14 +45,12 @@ func ExampleEnumerator_Count() {
 
 func ExampleEnumerator_CountAll() {
 	subject := collection.AsEnumerable('a', 'b', 'c', 'd', 'e')
-	fmt.Println(subject.Enumerate(nil).CountAll())
+	fmt.Println(subject.Enumerate(context.Background()).CountAll())
 	// Output: 5
 }
 
 func ExampleEnumerator_ElementAt() {
-	done := make(chan struct{})
-	defer close(done)
-	fmt.Print(collection.Fibonacci.Enumerate(done).ElementAt(4))
+	fmt.Print(collection.Fibonacci.Enumerate(context.Background()).ElementAt(4))
 	// Output: 3
 }
 
@@ -75,7 +74,7 @@ func ExampleLast() {
 
 func ExampleEnumerator_Last() {
 	subject := collection.AsEnumerable(1, 2, 3)
-	fmt.Print(subject.Enumerate(nil).Last())
+	fmt.Print(subject.Enumerate(context.Background()).Last())
 	//Output: 3
 }
 
@@ -84,13 +83,13 @@ func ExampleMerge() {
 	b := collection.AsEnumerable(8, 16, 32)
 	c := collection.Merge(a, b)
 	sum := 0
-	for x := range c.Enumerate(nil) {
+	for x := range c.Enumerate(context.Background()) {
 		sum += x.(int)
 	}
 	fmt.Println(sum)
 
 	product := 1
-	for y := range a.Enumerate(nil) {
+	for y := range a.Enumerate(context.Background()) {
 		product *= y.(int)
 	}
 	fmt.Println(product)
@@ -100,7 +99,7 @@ func ExampleMerge() {
 }
 
 func ExampleEnumerator_Reverse() {
-	a := collection.AsEnumerable(1, 2, 3).Enumerate(nil)
+	a := collection.AsEnumerable(1, 2, 3).Enumerate(context.Background())
 	a = a.Reverse()
 	fmt.Println(a.ToSlice())
 	// Output: [3 2 1]
@@ -119,7 +118,7 @@ func ExampleSelect() {
 }
 
 func ExampleEnumerator_Select() {
-	subject := collection.AsEnumerable('a', 'b', 'c').Enumerate(nil)
+	subject := collection.AsEnumerable('a', 'b', 'c').Enumerate(context.Background())
 	const offset = 'a' - 1
 	results := subject.Select(func(a interface{}) interface{} {
 		return a.(rune) - offset
@@ -166,8 +165,8 @@ func ExampleEnumerator_SelectMany() {
 		},
 	)
 
-	beers := breweries.Enumerate(nil).SelectMany(func(brewer interface{}) collection.Enumerator {
-		return brewer.(BrewHouse).Beers.Enumerate(nil)
+	beers := breweries.Enumerate(context.Background()).SelectMany(func(brewer interface{}) collection.Enumerator {
+		return brewer.(BrewHouse).Beers.Enumerate(context.Background())
 	})
 
 	for beer := range beers {
@@ -185,11 +184,8 @@ func ExampleEnumerator_SelectMany() {
 }
 
 func ExampleSkip() {
-	done := make(chan struct{})
-	defer close(done)
-
 	trimmed := collection.Take(collection.Skip(collection.Fibonacci, 1), 3)
-	for entry := range trimmed.Enumerate(done) {
+	for entry := range trimmed.Enumerate(context.Background()) {
 		fmt.Println(entry)
 	}
 	// Output:
@@ -200,7 +196,7 @@ func ExampleSkip() {
 
 func ExampleEnumerator_Skip() {
 	subject := collection.AsEnumerable(1, 2, 3, 4, 5, 6, 7)
-	skipped := subject.Enumerate(nil).Skip(5)
+	skipped := subject.Enumerate(context.Background()).Skip(5)
 	for entry := range skipped {
 		fmt.Println(entry)
 	}
@@ -210,11 +206,8 @@ func ExampleEnumerator_Skip() {
 }
 
 func ExampleTake() {
-	done := make(chan struct{})
-	defer close(done)
-
 	taken := collection.Take(collection.Fibonacci, 4)
-	for entry := range taken.Enumerate(done) {
+	for entry := range taken.Enumerate(context.Background()) {
 		fmt.Println(entry)
 	}
 	// Output:
@@ -225,10 +218,7 @@ func ExampleTake() {
 }
 
 func ExampleEnumerator_Take() {
-	done := make(chan struct{})
-	defer close(done)
-
-	taken := collection.Fibonacci.Enumerate(done).Skip(4).Take(2)
+	taken := collection.Fibonacci.Enumerate(context.Background()).Skip(4).Take(2)
 	for entry := range taken {
 		fmt.Println(entry)
 	}
@@ -241,7 +231,7 @@ func ExampleTakeWhile() {
 	taken := collection.TakeWhile(collection.Fibonacci, func(x interface{}, n uint) bool {
 		return x.(int) < 10
 	})
-	for entry := range taken.Enumerate(nil) {
+	for entry := range taken.Enumerate(context.Background()) {
 		fmt.Println(entry)
 	}
 	// Output:
@@ -255,7 +245,7 @@ func ExampleTakeWhile() {
 }
 
 func ExampleEnumerator_TakeWhile() {
-	taken := collection.Fibonacci.Enumerate(nil).TakeWhile(func(x interface{}, n uint) bool {
+	taken := collection.Fibonacci.Enumerate(context.Background()).TakeWhile(func(x interface{}, n uint) bool {
 		return x.(int) < 6
 	})
 	for entry := range taken {
@@ -272,7 +262,7 @@ func ExampleEnumerator_TakeWhile() {
 
 func ExampleEnumerator_Tee() {
 	base := collection.AsEnumerable(1, 2, 4)
-	left, right := base.Enumerate(nil).Tee()
+	left, right := base.Enumerate(context.Background()).Tee()
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -313,7 +303,7 @@ func ExampleUCount() {
 
 func ExampleEnumerator_UCount() {
 	subject := collection.AsEnumerable("str1", "str1", "str2")
-	count1 := subject.Enumerate(nil).UCount(func(a interface{}) bool {
+	count1 := subject.Enumerate(context.Background()).UCount(func(a interface{}) bool {
 		return a == "str1"
 	})
 	fmt.Println(count1)
@@ -328,14 +318,12 @@ func ExampleUCountAll() {
 
 func ExampleEnumerator_UCountAll() {
 	subject := collection.AsEnumerable('a', 2, "str1")
-	fmt.Println(subject.Enumerate(nil).UCountAll())
+	fmt.Println(subject.Enumerate(context.Background()).UCountAll())
 	// Output: 3
 }
 
 func ExampleEnumerator_Where() {
-	done := make(chan struct{})
-	defer close(done)
-	results := collection.Fibonacci.Enumerate(done).Where(func(a interface{}) bool {
+	results := collection.Fibonacci.Enumerate(context.Background()).Where(func(a interface{}) bool {
 		return a.(int) > 8
 	}).Take(3)
 	fmt.Println(results.ToSlice())

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -31,7 +32,7 @@ func BenchmarkEnumerator_Sum(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for range nums.Enumerate(nil).Select(sleepIdentity) {
+		for range nums.Enumerate(context.Background()).Select(sleepIdentity) {
 			// Intentionally Left Blank
 		}
 	}

--- a/queue.go
+++ b/queue.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"context"
 	"sync"
 )
 
@@ -29,10 +30,10 @@ func (q *Queue) Add(entry interface{}) {
 }
 
 // Enumerate peeks at each element of this queue without mutating it.
-func (q *Queue) Enumerate(cancel <-chan struct{}) Enumerator {
+func (q *Queue) Enumerate(ctx context.Context) Enumerator {
 	q.key.RLock()
 	defer q.key.RUnlock()
-	return q.underlyer.Enumerate(cancel)
+	return q.underlyer.Enumerate(ctx)
 }
 
 // IsEmpty tests the Queue to determine if it is populate or not.

--- a/stack.go
+++ b/stack.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"context"
 	"sync"
 )
 
@@ -22,11 +23,11 @@ func NewStack(entries ...interface{}) *Stack {
 }
 
 // Enumerate peeks at each element in the stack without mutating it.
-func (stack *Stack) Enumerate(cancel <-chan struct{}) Enumerator {
+func (stack *Stack) Enumerate(ctx context.Context) Enumerator {
 	stack.key.RLock()
 	defer stack.key.RUnlock()
 
-	return stack.underlyer.Enumerate(cancel)
+	return stack.underlyer.Enumerate(ctx)
 }
 
 // IsEmpty tests the Stack to determine if it is populate or not.


### PR DESCRIPTION
In v1, raw channels are used. Not really a problem, but a new idiom has become popular since this library was originally authored, and this makes the muscle memory easier.

Fixes #7 