### PR TITLE
Fix uncancelled contexts

### DIFF
--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -55,7 +55,10 @@ func ExampleDirectory_Enumerate() {
 		Options:  DirectoryOptionsExcludeDirectories,
 	}
 
-	filesOfInterest := traverser.Enumerate(context.Background()).Select(func(subject interface{}) (result interface{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	filesOfInterest := traverser.Enumerate(ctx).Select(func(subject interface{}) (result interface{}) {
 		cast, ok := subject.(string)
 		if ok {
 			result = path.Base(cast)

--- a/query.go
+++ b/query.go
@@ -61,7 +61,10 @@ func (e emptyEnumerable) Enumerate(ctx context.Context) Enumerator {
 
 // All tests whether or not all items present in an Enumerable meet a criteria.
 func All(subject Enumerable, p Predicate) bool {
-	return subject.Enumerate(context.Background()).All(p)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	return subject.Enumerate(ctx).All(p)
 }
 
 // All tests whether or not all items present meet a criteria.
@@ -76,7 +79,10 @@ func (iter Enumerator) All(p Predicate) bool {
 
 // Any tests an Enumerable to see if there are any elements present.
 func Any(iterator Enumerable) bool {
-	for range iterator.Enumerate(context.Background()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for range iterator.Enumerate(ctx) {
 		return true
 	}
 	return false
@@ -84,7 +90,10 @@ func Any(iterator Enumerable) bool {
 
 // Anyp tests an Enumerable to see if there are any elements present that meet a criteria.
 func Anyp(iterator Enumerable, p Predicate) bool {
-	for element := range iterator.Enumerate(context.Background()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for element := range iterator.Enumerate(ctx) {
 		if p(element) {
 			return true
 		}
@@ -158,8 +167,7 @@ func (iter Enumerator) AsEnumerable() Enumerable {
 	return enumerableSlice(iter.ToSlice())
 }
 
-// Count iterates over a list and keeps a running tally of the number of elements
-// satisfy a predicate.
+// Count iterates over a list and keeps a running tally of the number of elements which satisfy a predicate.
 func Count(iter Enumerable, p Predicate) int {
 	return iter.Enumerate(context.Background()).Count(p)
 }
@@ -200,7 +208,10 @@ func (iter Enumerator) Discard() {
 
 // ElementAt retreives an item at a particular position in an Enumerator.
 func ElementAt(iter Enumerable, n uint) interface{} {
-	return iter.Enumerate(context.Background()).ElementAt(n)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	return iter.Enumerate(ctx).ElementAt(n)
 }
 
 // ElementAt retreives an item at a particular position in an Enumerator.
@@ -213,11 +224,13 @@ func (iter Enumerator) ElementAt(n uint) interface{} {
 
 // First retrieves just the first item in the list, or returns an error if there are no elements in the array.
 func First(subject Enumerable) (retval interface{}, err error) {
-	err = errNoElements
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
+	err = errNoElements
 	var isOpen bool
 
-	if retval, isOpen = <-subject.Enumerate(context.Background()); isOpen {
+	if retval, isOpen = <-subject.Enumerate(ctx); isOpen {
 		err = nil
 	}
 
@@ -424,10 +437,12 @@ func (iter Enumerator) SelectMany(lister Unfolder) Enumerator {
 
 // Single retreives the only element from a list, or returns nil and an error.
 func Single(iter Enumerable) (retval interface{}, err error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	err = errNoElements
 
 	firstPass := true
-	for entry := range iter.Enumerate(context.Background()) {
+	for entry := range iter.Enumerate(ctx) {
 		if firstPass {
 			retval = entry
 			err = nil

--- a/query_examples_test.go
+++ b/query_examples_test.go
@@ -50,7 +50,11 @@ func ExampleEnumerator_CountAll() {
 }
 
 func ExampleEnumerator_ElementAt() {
-	fmt.Print(collection.Fibonacci.Enumerate(context.Background()).ElementAt(4))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// ElementAt leaves the Enumerator open, creating a memory leak unless remediated,
+	// context.Context should be cancelled to indicate that no further reads are coming.
+	fmt.Print(collection.Fibonacci.Enumerate(ctx).ElementAt(4))
 	// Output: 3
 }
 
@@ -206,8 +210,11 @@ func ExampleEnumerator_Skip() {
 }
 
 func ExampleTake() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	taken := collection.Take(collection.Fibonacci, 4)
-	for entry := range taken.Enumerate(context.Background()) {
+	for entry := range taken.Enumerate(ctx) {
 		fmt.Println(entry)
 	}
 	// Output:
@@ -218,7 +225,10 @@ func ExampleTake() {
 }
 
 func ExampleEnumerator_Take() {
-	taken := collection.Fibonacci.Enumerate(context.Background()).Skip(4).Take(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	taken := collection.Fibonacci.Enumerate(ctx).Skip(4).Take(2)
 	for entry := range taken {
 		fmt.Println(entry)
 	}
@@ -231,7 +241,11 @@ func ExampleTakeWhile() {
 	taken := collection.TakeWhile(collection.Fibonacci, func(x interface{}, n uint) bool {
 		return x.(int) < 10
 	})
-	for entry := range taken.Enumerate(context.Background()) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for entry := range taken.Enumerate(ctx) {
 		fmt.Println(entry)
 	}
 	// Output:
@@ -245,7 +259,10 @@ func ExampleTakeWhile() {
 }
 
 func ExampleEnumerator_TakeWhile() {
-	taken := collection.Fibonacci.Enumerate(context.Background()).TakeWhile(func(x interface{}, n uint) bool {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	taken := collection.Fibonacci.Enumerate(ctx).TakeWhile(func(x interface{}, n uint) bool {
 		return x.(int) < 6
 	})
 	for entry := range taken {
@@ -261,8 +278,11 @@ func ExampleEnumerator_TakeWhile() {
 }
 
 func ExampleEnumerator_Tee() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	base := collection.AsEnumerable(1, 2, 4)
-	left, right := base.Enumerate(context.Background()).Tee()
+	left, right := base.Enumerate(ctx).Tee()
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -323,7 +343,10 @@ func ExampleEnumerator_UCountAll() {
 }
 
 func ExampleEnumerator_Where() {
-	results := collection.Fibonacci.Enumerate(context.Background()).Where(func(a interface{}) bool {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	results := collection.Fibonacci.Enumerate(ctx).Where(func(a interface{}) bool {
 		return a.(int) > 8
 	}).Take(3)
 	fmt.Println(results.ToSlice())


### PR DESCRIPTION
When merging a feature branch with `v2`, I discovered a bunch of places where contexts not being cancelled would introduce memory leaks. This PR seeks to _at least_ fix any gaps that were introduced with #17 and some low-hanging fruit. But there are likely other places too.