### PR TITLE
Move DictionaryExample outside of package for clarity.

### DIFF
--- a/dictionary_examples_test.go
+++ b/dictionary_examples_test.go
@@ -51,9 +51,7 @@ func ExampleDictionary_Enumerate() {
 	subject.Add("world")
 	subject.Add("hello")
 
-	upperCase := collection.Select[string](subject, func(x string) string {
-		return strings.ToUpper(x)
-	})
+	upperCase := collection.Select[string](subject, strings.ToUpper)
 
 	for word := range subject.Enumerate(context.Background()) {
 		fmt.Println(word)

--- a/filesystem_examples_test.go
+++ b/filesystem_examples_test.go
@@ -1,0 +1,30 @@
+package collection_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/marstr/collection/v2"
+	"path"
+)
+
+func ExampleDirectory_Enumerate() {
+	traverser := collection.Directory{
+		Location: ".",
+		Options:  collection.DirectoryOptionsExcludeDirectories,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fileNames := collection.Select[string](traverser, path.Base)
+
+	filesOfInterest := collection.Where(fileNames, func(subject string) bool {
+		return subject == "filesystem_examples_test.go"
+	})
+
+	for entry := range filesOfInterest.Enumerate(ctx) {
+		fmt.Println(entry)
+	}
+
+	// Output: filesystem_examples_test.go
+}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"path"
 	"path/filepath"
 	"testing"
 )
@@ -47,30 +46,6 @@ func TestEnumerateDirectoryOptions_UniqueBits(t *testing.T) {
 			t.Fail()
 		}
 	}
-}
-
-func ExampleDirectory_Enumerate() {
-	traverser := Directory{
-		Location: ".",
-		Options:  DirectoryOptionsExcludeDirectories,
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	fileNames := Select[string](traverser, func(subject string) string {
-		return path.Base(subject)
-	})
-
-	filesOfInterest := Where(fileNames, func(subject string) bool {
-		return subject == "filesystem_test.go"
-	})
-
-	for entry := range filesOfInterest.Enumerate(ctx) {
-		fmt.Println(entry)
-	}
-
-	// Output: filesystem_test.go
 }
 
 func TestDirectory_Enumerate(t *testing.T) {


### PR DESCRIPTION
Also, opportunistically remove extra boiler plate around lambdas that isn't necessary now that we have generics.