### PR TITLE
Fix mistargeted example

### DIFF
--- a/query_examples_test.go
+++ b/query_examples_test.go
@@ -128,7 +128,7 @@ func ExampleSelect() {
 	// Output: [1 2 3]
 }
 
-func ExampleEnumerator_SelectMany() {
+func ExampleSelectMany() {
 
 	type BrewHouse struct {
 		Name  string


### PR DESCRIPTION
The old name misattributed a global method to a particular type, breaking the build.